### PR TITLE
Add footnotes to typst export

### DIFF
--- a/backend/src/lib/derivation/statement.rs
+++ b/backend/src/lib/derivation/statement.rs
@@ -16,6 +16,7 @@ use super::formula::{Formula, Identifier};
     Serialize, Deserialize, Debug, Clone, ToSchema, IntoParams, Ord, PartialEq, PartialOrd, Eq,
 )]
 pub struct Statement {
+    #[serde(default)]
     pub lhs: Vec<Formula>,
     pub formula: Formula,
     pub sidecondition: Vec<SideCondition>,

--- a/frontend/src/lib/components/createExercise.tsx
+++ b/frontend/src/lib/components/createExercise.tsx
@@ -98,7 +98,7 @@ const CreateExerciseForm = () => {
           createExerciseRequest: {
             statement: {
               formula: rhs,
-              lhs: lhs,
+              lhs: lhs || [],
               sidecondition: sideCon,
             },
           },

--- a/frontend/src/lib/components/exercise/exerciseInterface.tsx
+++ b/frontend/src/lib/components/exercise/exerciseInterface.tsx
@@ -45,7 +45,7 @@ const ExerciseInterface = ({ exercise }: ExerciseInterfaceProps) => {
         </Box>
       )}
       <Flex pt={0}>
-        {exercise.sidecondition.map((sidecondition, index) => (
+        {exercise.sidecondition?.map((sidecondition, index) => (
           <SideCondition sideCondition={sidecondition} key={index} />
         ))}
       </Flex>

--- a/frontend/src/lib/components/exerciseListElement.tsx
+++ b/frontend/src/lib/components/exerciseListElement.tsx
@@ -108,7 +108,7 @@ const ExerciseListElment = ({ exercise }: exerciseListElementProps) => {
           </Indicator>
         </Link>
       </Flex>
-      {exercise.exercise.sidecondition.map((sideCondition, i) => (
+      {exercise.exercise.sidecondition?.map((sideCondition, i) => (
         <SideCondition sideCondition={sideCondition} key={i} />
       ))}
     </Card>

--- a/frontend/src/lib/utils/export.ts
+++ b/frontend/src/lib/utils/export.ts
@@ -37,7 +37,7 @@ function exportSubformula(node: NodeType, nodes: Array<NodeType>, footnoteNumber
       .replaceAll("%%identifier%%", formula.body.identifier.value)
       .replaceAll("%%lhs%%", lhs)
       .replaceAll("%%rhs%%", current);
-    footnotes.push([footnoteNumber, name[1]]);
+    footnotes.push([footnoteNumber, footnote]);
     name = name[0];
   };
 
@@ -47,9 +47,9 @@ function exportSubformula(node: NodeType, nodes: Array<NodeType>, footnoteNumber
     })
     .filter(Boolean)
     .map((node) => {
-      const [subformula, footnotes] = exportSubformula(node as NodeType, nodes, currentFootnoteNumber);
-      currentFootnoteNumber += footnotes.length;
-      footnotes.push(...footnotes);
+      const [subformula, extraFootnotes] = exportSubformula(node as NodeType, nodes, currentFootnoteNumber);
+      currentFootnoteNumber += extraFootnotes.length;
+      footnotes.push(...extraFootnotes);
       return subformula;
     })
     .join(",\n");

--- a/frontend/src/lib/utils/export.ts
+++ b/frontend/src/lib/utils/export.ts
@@ -8,7 +8,7 @@ export function exportToTypst(root: NodeType, nodes: Array<NodeType>): string {
   const [formula, footnotes] = exportSubformula(root, nodes, 1);
   const prooftree = `#prooftree(${formula})`;
 
-  const conditions = root.statement.sidecondition.map(({ NotFree: { element, placeholder } }) => {
+  const conditions = (root.statement.sidecondition || []).map(({ NotFree: { element, placeholder } }) => {
     return `${element.value} "not occuring freely in" ${placeholder.value}`
   });
   conditions.push(...footnotes.map(([id, note]) => `$"${id}:" ${note}$`));
@@ -18,7 +18,7 @@ export function exportToTypst(root: NodeType, nodes: Array<NodeType>): string {
   if (conditions.length > 0) {
     typstStr += "\n#set text(size: 7pt)"
     typstStr += "\n#let footnotes(body) = context {\n\tpad(top: 4pt, line(length: measure(body).width, stroke: 0.5pt + black))\n\tbody\n}";
-    typstStr += `\n#stack(dir: ttb, spacing: 4pt, ${conditions.join(", ")})`
+    typstStr += `\n#footnotes[#stack(dir: ttb, spacing: 4pt, ${conditions.join(", ")})]`
   }
 
   return typstStr;

--- a/frontend/src/lib/utils/export.ts
+++ b/frontend/src/lib/utils/export.ts
@@ -79,7 +79,7 @@ function formulaToTypst(formula: Formula): string {
       return `exists ${formulaToTypst({ type: "Ident", body: formula.body.identifier })}. ${formulaToTypst(formula.body.formula)}`;
     case "Predicate": {
       const vars = formula.body.identifiers.map((id) => id.value).join(", ");
-      return `${formula.body.identifier}(${vars})`;
+      return `${formula.body.identifier.value}(${vars})`;
     }
     default:
       return "";

--- a/frontend/src/lib/utils/rule.ts
+++ b/frontend/src/lib/utils/rule.ts
@@ -41,7 +41,7 @@ export function getRuleByName(name: Rules): string {
   }
 }
 
-export function getTypstRuleByName(name: Rules): string {
+export function getTypstRuleByName(name: Rules, footnote: number): string | [string, string] {
   switch (name) {
     case "AndElimL":
       return 'and "EL"';
@@ -52,7 +52,7 @@ export function getTypstRuleByName(name: Rules): string {
     case "Ax":
       return '"AXIOM"';
     case "ExistsElim":
-      return 'exists "E**"';
+      return [`exists "E"^(${footnote})`, '%%identifier%% "does not occur freely in any formula in" %%lhs%% "or" %%rhs%%'];
     case "ExistsIntro":
       return 'exists "I"';
     case "FalseElim":
@@ -60,7 +60,7 @@ export function getTypstRuleByName(name: Rules): string {
     case "ForallElim":
       return 'forall "E"';
     case "ForallIntro":
-      return 'forall "I*"';
+      return [`forall "I"^$(${footnote})`, '%%identifier%% "does not occur freely in any formula in" %%lhs%%'];
     case "ImplElim":
       return 'arrow.r "E"';
     case "ImplIntro":
@@ -76,8 +76,8 @@ export function getTypstRuleByName(name: Rules): string {
     case "OrIntroR":
       return 'or "I"';
     case "AlphaExists":
-      return 'alpha exists "***"';
+      return [`alpha exists^(${footnote})`, '"the binding structure is preserved"'];
     case "AlphaForall":
-      return 'alpha forall "***"';
+      return [`alpha forall^(${footnote})`, '"the binding structure is preserved"'];
   }
 }


### PR DESCRIPTION
The typst export now contains footnotes about conditions. An example is attached below (clearly visible):

![image](https://github.com/user-attachments/assets/c87baa24-879b-4889-8970-444486eda713)

I've only tested it with simple formulas since I didn't want to solve a more advanced one