### PR TITLE
Added basic usage tracker to root-layout.ts

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -31,6 +31,7 @@ export default function RootLayout({
     <html lang="en" {...mantineHtmlProps}>
       <head>
         <ColorSchemeScript />
+        <script defer src="https://umami.mcandri13.ch/script.js" data-website-id="77d5cac2-7526-455d-bdc9-3900e72adb09"></script>
       </head>
       <body>
         <StoreProvider>


### PR DESCRIPTION
Let's check how popular the website is right now with midterms approaching. Regarding GDPR compliance, UMAMI itself says the following

<img width="756" alt="image" src="https://github.com/user-attachments/assets/d39db33f-8bf3-4aec-8160-c839dd57dcc2" />

Hence, no problems here :)